### PR TITLE
Add Antony Ojwang as a microfrontends squad member

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Current members of the microfrontends squad:
 - @Fatmali (Ampath)
 - @brandones (PIH)
 - @angshu (Bahmni)
+- @ojwanganto (Kenya EMR)
 
 Other groups who'd like to participate in the microfrontends squad can contact the squad on Talk.
 


### PR DESCRIPTION
Antony has joined our microfrontends squad, is attending the weekly meetings, has already approved some of the previous RFC PRs, and is representing Kenya EMR in the microfrontends squad.